### PR TITLE
Add GIFT-Simulator / GIFT-Development reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ Links to larger projects based on this one
 - [GIFT-Simulator](https://leukipp.github.io/xmastree/files/simulator/): 
 Check online how your CSV animations may look like on a "real" tree. 
 Files published here in the `examples` folder are automatically retrieved and immediately available.
+- [GIFT-Development](https://leukipp.github.io/xmastree/lab/): 
+Start coding right away with Jupyter Lab notebooks in `python`, `javascript` and `p5.js`.


### PR DESCRIPTION
Added reference to an online simulator and integrated development environment:
![app](https://github.com/leukipp/xmastree/raw/develop/jupyter/img/app.gif)

Further details can be found [here](https://github.com/leukipp/xmastree/blob/develop/jupyter/files/simulator/README.md) and [here](https://github.com/leukipp/xmastree/blob/develop/jupyter/README.md).