### PR TITLE
Added run.py to run files at constant framerate

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""
+Usage: run.py <file> [brightness_factor]
+
+file: The GIFT file to play
+brightness_factor: (optional) factor to multiply all brightness values with. All values clamped at 255.
+"""
+
+import board
+import csv
+import neopixel
+import sys
+import time 
+
+
+NUMBER_OF_LEDS = 500
+FRAME_TIME = 1 / 30
+
+pixels = neopixel.NeoPixel(board.D18, NUMBER_OF_LEDS, auto_write=False, pixel_order=neopixel.RGB)
+
+csv_file = sys.argv[1]
+
+brightness_factor = 1.
+if len(sys.argv) >= 3:
+    brightness_factor = float(sys.argv[2])
+
+
+# load csv
+frames = []
+
+with open(csv_file, 'r') as file:
+    # pass the file object to reader() to get the reader object
+    csv_reader = csv.reader(file)
+
+    # skip header row
+    next(csv_reader)
+
+    for row in csv_reader:
+        values = [
+            min(255, # clamp at 255
+                int(
+                    float(x) * brightness_factor
+                )
+            )
+            for x in row[1:] # skip first column (FRAME_ID)
+        ]
+        frames.append([(values[i+0], values[i+1], values[i+2]) for i in range(0, len(values), 3)])
+
+print("Finished Parsing")
+
+
+
+# run the code on the tree
+frame_start = time.time()
+
+f = 0
+while f < len(frames):
+    #print("running frame " + str(f))
+    
+    pixels[:] = frames[f]
+    pixels.show()
+
+    f += 1
+    
+    # sleep to wait for next frame
+    frame_start += FRAME_TIME
+    sleep_time = frame_start - time.time()
+    if sleep_time > 0.:
+        time.sleep(sleep_time)
+    
+    # skip frames if lagging behind
+    elif sleep_time < -FRAME_TIME:
+        skip = int(-sleep_time // FRAME_TIME)
+        f += skip
+        frame_start += skip * FRAME_TIME


### PR DESCRIPTION
Adds a `run.py` file that runs GIFT files at a constant framerate of 30fps.

On my Pi 4B the maximum framerate using this script is ~35 (with tricks it can be pushed to ~39).
I chose 30 as a target, as it's a common number and has some headroom.
Should it be necessary it will skip frames to keep the speed constant.

It also accepts a `brightness_factor` as an optional second argument, which all brightness values are multiplied by.
(All values are clamped to 255)
